### PR TITLE
Add placeholderBackgroundColor property

### DIFF
--- a/Example/RAGTextField/Outline.storyboard
+++ b/Example/RAGTextField/Outline.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1JK-I3-CJQ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1JK-I3-CJQ">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,14 +36,20 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Outline and fill" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bX2-JK-SPz" customClass="RAGTextField" customModule="RAGTextField">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Outline Background Placeholder" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WI6-3J-Bhw" customClass="RAGTextField" customModule="RAGTextField">
                                                 <rect key="frame" x="0.0" y="80" width="343" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Box" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="I8g-Tx-mDI" customClass="RAGTextField" customModule="RAGTextField">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Outline and fill" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bX2-JK-SPz" customClass="RAGTextField" customModule="RAGTextField">
                                                 <rect key="frame" x="0.0" y="126" width="343" height="30"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Box" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="I8g-Tx-mDI" customClass="RAGTextField" customModule="RAGTextField">
+                                                <rect key="frame" x="0.0" y="172" width="343" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -73,6 +79,7 @@
                     <connections>
                         <outlet property="boxTextField" destination="I8g-Tx-mDI" id="JWQ-7k-fOs"/>
                         <outlet property="outlineAndFillTextField" destination="bX2-JK-SPz" id="VNR-ga-2fm"/>
+                        <outlet property="outlinePlaceholderBackgroundColorTextField" destination="WI6-3J-Bhw" id="qME-ji-sRz"/>
                         <outlet property="outlineTextField" destination="x8q-DG-EER" id="1Z9-jW-nUl"/>
                     </connections>
                 </viewController>

--- a/Example/RAGTextField/OutlineViewController.swift
+++ b/Example/RAGTextField/OutlineViewController.swift
@@ -23,6 +23,28 @@ final class OutlineViewController: UIViewController, UITextFieldDelegate {
             outlineTextField.placeholderColor = ColorPalette.savanna
         }
     }
+
+    @IBOutlet private weak var outlinePlaceholderBackgroundColorTextField: RAGTextField! {
+        didSet {
+            outlinePlaceholderBackgroundColorTextField.delegate = self
+
+            let bgView = OutlineView(frame: .zero)
+            bgView.lineWidth = 1
+            bgView.lineColor = ColorPalette.savanna
+            bgView.fillColor = nil
+            bgView.cornerRadius = 6.0
+            outlinePlaceholderBackgroundColorTextField.textColor = ColorPalette.stone
+            outlinePlaceholderBackgroundColorTextField.tintColor = ColorPalette.stone
+            outlinePlaceholderBackgroundColorTextField.textBackgroundView = bgView
+            outlinePlaceholderBackgroundColorTextField.textPadding = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 8.0)
+            outlinePlaceholderBackgroundColorTextField.textPaddingMode = .text
+            outlinePlaceholderBackgroundColorTextField.scaledPlaceholderOffset = -6.5
+            outlinePlaceholderBackgroundColorTextField.placeholderMode = .scalesWhenEditing
+            outlinePlaceholderBackgroundColorTextField.placeholderScaleWhenEditing = 0.8
+            outlinePlaceholderBackgroundColorTextField.placeholderColor = ColorPalette.savanna
+            outlinePlaceholderBackgroundColorTextField.placeholderBackgroundColor = UIColor.white
+        }
+    }
     
     @IBOutlet private weak var outlineAndFillTextField: RAGTextField! {
         didSet {

--- a/RAGTextField/Classes/RAGTextField.swift
+++ b/RAGTextField/Classes/RAGTextField.swift
@@ -235,7 +235,16 @@ open class RAGTextField: UITextField {
             updatePlaceholderColor()
         }
     }
-    
+
+    /// The background color of the placeholder.
+    ///
+    /// If `nil`, the background color of the text field is used instead.
+    @IBInspectable open var placeholderBackgroundColor: UIColor? {
+        didSet {
+            placeholderLabel.backgroundColor = placeholderBackgroundColor
+        }
+    }
+
     /// The text color of the placeholder while it is transformed and being edited.
     ///
     /// If `nil` (default), the `placeholderColor` is applied to the transformed placeholder.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 <img src="https://user-images.githubusercontent.com/1574034/53834942-8fad9580-3f8c-11e9-944a-ff22aee1bc58.png" width="15%"></img>
 <img src="https://user-images.githubusercontent.com/1574034/53834949-94724980-3f8c-11e9-9695-b2b4991da67e.png" width="15%"></img> 
 <img src="https://user-images.githubusercontent.com/1574034/53834951-950ae000-3f8c-11e9-8abd-4558d3fb0a72.png" width="15%"></img>
-<img src="https://user-images.githubusercontent.com/1574034/53834952-95a37680-3f8c-11e9-8694-58248b29c56b.png" width="15%"></img> 
+<img src="https://user-images.githubusercontent.com/1376242/62060049-b9f63d00-b224-11e9-8d31-8ba551459ea6.png" width="15%"></img> 
 <img src="https://user-images.githubusercontent.com/1574034/53834953-95a37680-3f8c-11e9-9dc3-f27474ba2e9b.png" width="15%"></img> 
 <img src="https://user-images.githubusercontent.com/1574034/53834954-95a37680-3f8c-11e9-92fd-8833bd466bc0.png" width="15%"></img> 
 
@@ -74,6 +74,7 @@ These are the different ways you can **customize the appearance** and behavior o
 
 - Use the `placeholderFont` property to assign a **custom font or font size** to the placeholder. By default, the placeholder uses the font of the text field.
 - Use the `placeholderColor` property to **change the color** of the placeholder. By default, the placeholder uses the text color of the text field.
+- Use the `placeholderBackgroundColor` property to **change the background color** of the placeholder. By default, the placeholder bacground color is clear.
 - Use the `transformedPlaceholderColor` property to set a color that is applied to the placeholder when the text field is being edited and the placeholder is transformed to its floating position.
 - Use the `placeholderScaleWhenEditing` property to specify the **scale applied to the placeholder** in its floating position above the text. The default value is 1.
 - Use the `scaledPlaceholderOffset` property to offset the placeholder in its floating position from the text. The default value is 0. Positive values **move the placeholder up**, away from the text.


### PR DESCRIPTION
Adding a background color property allow developers to approach floating placeholder on textfields like material design. 

See the label at the bottom right for example: 
![](https://storage.googleapis.com/spec-host/mio-staging%2Fmio-design%2F1563837804615%2Fassets%2F18fktKxSS5YHo2MIf3mm3VzLPoGyEUKRq%2Ftextfields-types.png)